### PR TITLE
Openal improvement

### DIFF
--- a/src/SharpAudio.ALBinding/Al.cs
+++ b/src/SharpAudio.ALBinding/Al.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 
 #pragma warning disable CS1591
@@ -82,6 +82,11 @@ namespace SharpAudio.ALBinding
         private delegate int AL_getError_t();
         private static AL_getError_t s_al_getError;
         public static int alGetError() => s_al_getError();
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate IntPtr AL_getString_t(int param);
+        private static AL_getString_t s_al_getString;
+        public static IntPtr alGetString(int param) => s_al_getString(param);
 
         /* n refers to an ALsizei */
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -185,6 +190,7 @@ namespace SharpAudio.ALBinding
         private static void LoadAl()
         {
             s_al_getError = LoadFunction<AL_getError_t>("alGetError");
+            s_al_getString = LoadFunction<AL_getString_t>("alGetString");
 
             s_al_isExtensionPresent = LoadFunction<AL_isExtensionPresent_t>("alIsExtensionPresent");
 

--- a/src/SharpAudio.ALBinding/Alc.cs
+++ b/src/SharpAudio.ALBinding/Alc.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 
 #pragma warning disable CS1591
@@ -42,6 +42,12 @@ namespace SharpAudio.ALBinding
         public static int alcGetError(IntPtr device) => s_alc_getError(device);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate IntPtr ALC_getString_t(IntPtr device, int param);
+        private static ALC_getString_t s_alc_getString;
+        public static IntPtr alcGetString(IntPtr device, int param) => s_alc_getString(device, param);
+
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate IntPtr ALC_createContext_t(IntPtr device, int[] attribs);
         private static ALC_createContext_t s_alc_createContext;
         public static IntPtr alcCreateContext(IntPtr device, int[] attribs) => s_alc_createContext(device, attribs);
@@ -49,12 +55,37 @@ namespace SharpAudio.ALBinding
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void ALC_makeContextCurrent_t(IntPtr context);
         private static ALC_makeContextCurrent_t s_alc_makeContextCurrent;
-        public static void alcMakeContextCurrent(IntPtr handle) => s_alc_makeContextCurrent(handle);
+        public static void alcMakeContextCurrent(IntPtr context) => s_alc_makeContextCurrent(context);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void ALC_destroyContext_t(IntPtr context);
         private static ALC_destroyContext_t s_alc_destroyContext;
-        public static void alcDestroyContext(IntPtr handle) => s_alc_destroyContext(handle);
+        public static void alcDestroyContext(IntPtr context) => s_alc_destroyContext(context);
+
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void ALC_processContext_t(IntPtr context);
+        private static ALC_processContext_t s_alc_processContext;
+        public static void alcProcessContext(IntPtr context) => s_alc_processContext(context);
+
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void ALC_suspendContext_t(IntPtr context);
+        private static ALC_suspendContext_t s_alc_suspendContext;
+        public static void alcSuspendContext(IntPtr context) => s_alc_suspendContext(context);
+
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate IntPtr ALC_GetCurrentContext_t();
+        private static ALC_GetCurrentContext_t s_alc_getCurrentContext;
+        public static IntPtr alcGetCurrentContext() => s_alc_getCurrentContext();
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate IntPtr ALC_GetCurrentDevice_t(IntPtr context);
+        private static ALC_GetCurrentDevice_t s_alc_getCurrentDevice;
+        public static IntPtr alcGetContextsDevice(IntPtr context) => s_alc_getCurrentDevice(context);
+
+
 
         private static void LoadAlc()
         {
@@ -62,11 +93,18 @@ namespace SharpAudio.ALBinding
             s_alc_closeDevice = LoadFunction<ALC_closeDevice_t>("alcCloseDevice");
 
             s_alc_getError = LoadFunction<ALC_getError_t>("alcGetError");
+            s_alc_getString = LoadFunction<ALC_getString_t>("alcGetString");
 
             s_alc_createContext = LoadFunction<ALC_createContext_t>("alcCreateContext");
             s_alc_destroyContext = LoadFunction<ALC_destroyContext_t>("alcDestroyContext");
 
+            s_alc_processContext = LoadFunction<ALC_processContext_t>("alcProcessContext");
+            s_alc_suspendContext = LoadFunction<ALC_suspendContext_t>("alcSuspendContext");
+
             s_alc_makeContextCurrent = LoadFunction<ALC_makeContextCurrent_t>("alcMakeContextCurrent");
+
+            s_alc_getCurrentContext = LoadFunction<ALC_GetCurrentContext_t>("alcGetCurrentContext");
+            s_alc_getCurrentDevice = LoadFunction<ALC_GetCurrentDevice_t>("alcGetContextsDevice");
         }
     }
 }

--- a/src/SharpAudio/AL/ALEngine.cs
+++ b/src/SharpAudio/AL/ALEngine.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using SharpAudio.ALBinding;
 
 namespace SharpAudio.AL
@@ -23,33 +23,15 @@ namespace SharpAudio.AL
             checkAlError();
         }
 
-        private static String openAlErrorToString(int err)
-        {
-            switch (err)
-            {
-                case AlNative.AL_NO_ERROR:
-                    return "AL_NO_ERROR";
-                case AlNative.AL_INVALID_NAME:
-                    return "AL_INVALID_NAME";
-                case AlNative.AL_INVALID_ENUM:
-                    return "AL_INVALID_ENUM";
-                case AlNative.AL_INVALID_VALUE:
-                    return "AL_INVALID_VALUE";
-                case AlNative.AL_INVALID_OPERATION:
-                    return "AL_INVALID_OPERATION";
-                case AlNative.AL_OUT_OF_MEMORY:
-                    return "AL_OUT_OF_MEMORY";
-                default:
-                    return "Unknown error code";
-            }
-        }
 
         internal static void checkAlError()
         {
             int error = AlNative.alGetError();
             if (error != AlNative.AL_NO_ERROR)
             {
-                throw new SharpAudioException("OpenAL Error: " + openAlErrorToString(error));
+                
+                string formatErrMsg = string.Format("OpenAL Error: {0} - {1}", Marshal.PtrToStringAuto(AlNative.alGetString(error)), AlNative.alcGetCurrentContext().ToString());
+                throw new SharpAudioException(formatErrMsg);
             }
         }
 
@@ -58,7 +40,8 @@ namespace SharpAudio.AL
             int error = AlNative.alcGetError(_device);
             if (error != AlNative.ALC_NO_ERROR)
             {
-                throw new SharpAudioException("OpenAL Error: " + error);
+                string formatErrMsg = string.Format("OpenALc Error: {0}", Marshal.PtrToStringAuto(AlNative.alcGetString(_device, error)));
+                throw new SharpAudioException(formatErrMsg);
             }
         }
 

--- a/src/SharpAudio/AL/ALEngine.cs
+++ b/src/SharpAudio/AL/ALEngine.cs
@@ -18,7 +18,8 @@ namespace SharpAudio.AL
         public ALEngine(AudioEngineOptions options)
         {
             mutex.WaitOne();
-            if (Interlocked.Increment(ref usingResource) == 1)
+            usingResource++;
+            if (usingResource == 1)
             {
                 int[] argument = new int[] { AlNative.ALC_FREQUENCY, options.SampleRate };
                 // opens the default device.
@@ -86,7 +87,7 @@ namespace SharpAudio.AL
                     _device = IntPtr.Zero;
 
                 }
-                Interlocked.Exchange(ref usingResource, 0);
+                usingResource = 0;
             }
             mutex.ReleaseMutex();
         }

--- a/src/SharpAudio/AL/ALSource.cs
+++ b/src/SharpAudio/AL/ALSource.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using SharpAudio.ALBinding;
 
 namespace SharpAudio.AL
@@ -22,13 +22,21 @@ namespace SharpAudio.AL
         public override float Volume
         {
             get { return _volume; }
-            set { _volume = value; AlNative.alSourcef(_source, AlNative.AL_GAIN, value); }
+            set
+            {
+                _volume = value; AlNative.alSourcef(_source, AlNative.AL_GAIN, value);
+                ALEngine.checkAlError();
+            }
         }
 
         public override bool Looping
         {
             get { return _looping; }
-            set { _looping = value; AlNative.alSourcei(_source, AlNative.AL_LOOPING, value ? 1 : 0); }
+            set
+            {
+                _looping = value; AlNative.alSourcei(_source, AlNative.AL_LOOPING, value ? 1 : 0);
+                ALEngine.checkAlError();
+            }
         }
 
         public ALSource()


### PR DESCRIPTION

Add better error message when error occurs.
Add additional error check on some forgotten OpenAL calls.

Changed so that a single OpenAL context can only exist, while having each instance of the ALEngine object  sharing the OpenAL context. And only release the OpenAL context when no instance of ALEngine remains.