### PR TITLE
Check if `SourceVoice` is null before disposing

### DIFF
--- a/src/SharpAudio/XA2/XA2Source.cs
+++ b/src/SharpAudio/XA2/XA2Source.cs
@@ -48,8 +48,8 @@ namespace SharpAudio.XA2
 
         public override void Dispose()
         {
-            SourceVoice.DestroyVoice();
-            SourceVoice.Dispose();
+            SourceVoice?.DestroyVoice();
+            SourceVoice?.Dispose();
         }
 
         public override bool IsPlaying()


### PR DESCRIPTION
Avoids `NullReferenceException` if `XA2Source` is created and destroyed without playing anything.

NOTE : I just had this issue and opened a PR on GitHub instead of an issue, but I didn't clone the project to test it.