### PR TITLE
Add default openal install path for macos

### DIFF
--- a/src/SharpAudio.ALBinding/AlNative.cs
+++ b/src/SharpAudio.ALBinding/AlNative.cs
@@ -32,6 +32,7 @@ namespace SharpAudio.ALBinding
             {
                 names = new[]
                 {
+                    "/usr/local/opt/openal-soft/lib/libopenal.dylib",
                     "libopenal.dylib",
                     "soft_oal.so"
                 };


### PR DESCRIPTION
Installing via `brew install openal-soft` installs openal to this location. openal for some reason won't resolve via PATH even though it should be accessible via my path variable 🤷 